### PR TITLE
Multiple changes following code review

### DIFF
--- a/fission_fusion/identify_splits_and_merges.R
+++ b/fission_fusion/identify_splits_and_merges.R
@@ -275,26 +275,9 @@ identify_splits_and_merges <- function(R_inner, R_outer, xs = xs, ys = ys, ts = 
     }
     
     #remove any now-empty groups from groups_curr and groups_next
-    g <- 1
-    gmax <- length(groups_curr)
-    while(g <= gmax){
-      if(length(groups_curr[[g]])==0){
-        groups_curr[[g]] <- NULL
-        g <- g - 1
-        gmax <- gmax - 1
-      }
-      g <- g + 1
-    }
-    g <- 1
-    gmax <- length(groups_next)
-    while(g <= gmax){
-      if(length(groups_next[[g]])==0){
-        groups_next[[g]] <- NULL
-        g <- g - 1
-        gmax <- gmax - 1
-      }
-      g <- g + 1
-    }
+    groups_curr[!unlist(lapply(groups_curr, length))] <- NULL
+    groups_next[!unlist(lapply(groups_next, length))] <- NULL
+    
     
     #find sets of connected groups across the current and future timestep
     #construct a directed network connection_net[i,j] where the rows represent groups in the 

--- a/fission_fusion/identify_splits_and_merges.R
+++ b/fission_fusion/identify_splits_and_merges.R
@@ -226,35 +226,17 @@ identify_splits_and_merges <- function(R_inner, R_outer, xs = xs, ys = ys, ts = 
   }
 
   #Identifying changes in group membership in consecutive time steps
-
   if(verbose){print('Identifying changes in group membership')}
   event_times <- c()
   for(d in 1:(length(breaks)-1)){
     t_day <- breaks[d]:(breaks[d+1]-1)
     for(t in t_day[1:(length(t_day)-1)]){
-      groups_curr <- groups_list[[t]]
-      groups_next <- groups_list[[t+1]]
-      ## If this or next timestep have no groups, skip
-      if(sum(!is.na(groups_curr))==0 | sum(!is.na(groups_next))==0){
+      
+      if(length(groups_list[[t]])==0 | length(groups_list[[t+1]])==0){
         next
       }
-      n_groups_curr <- length(groups_curr)
-      n_groups_next <- length(groups_next)
-      matches <- rep(F, n_groups_curr)
-      ## Identify groups in next timestep that are unchanged from current groups
-      for(i in 1:n_groups_curr){
-        group_curr <- groups_curr[[i]]
-        matched <- F
-        for(j in 1:n_groups_next){
-          group_next <- groups_next[[j]]
-          if(setequal(group_curr,group_next)){
-            matched <- T
-          }
-        }
-        matches[i] <- matched
-      }
-      ## If any groups don't have matches, store this time as a time in which a change event occurred
-      if(sum(matches)<n_groups_curr){
+      ## If any groups arent present in next step, store this time as a time in which a change event occurred
+      if(!all(groups_list[[t]] %in% groups_list[[t+1]])){
         event_times <- c(event_times, t)
       }
     }

--- a/fission_fusion/identify_splits_and_merges.R
+++ b/fission_fusion/identify_splits_and_merges.R
@@ -469,7 +469,7 @@ identify_splits_and_merges <- function(R_inner, R_outer, xs = xs, ys = ys, ts = 
   }
 
   #return things
-  out <- list(events_detected = events_detected, all_events_info = all_events_info, groups_list = groups_list, group_matrix = groups, together = together, R_inner = R_inner, R_outer = R_outer)
+  out <- list(events_detected = events_detected, all_events_info = all_events_info, groups_list = groups_list, groups = groups, together = together, R_inner = R_inner, R_outer = R_outer)
   return(out)
 
 }

--- a/fission_fusion/identify_splits_and_merges.R
+++ b/fission_fusion/identify_splits_and_merges.R
@@ -504,7 +504,7 @@ identify_splits_and_merges <- function(R_inner, R_outer, xs = xs, ys = ys, ts = 
   }
 
   #return things
-  out <- list(events_detected = events_detected, all_events_info = all_events_info, groups_list = groups_list, together = together, R_inner = R_inner, R_outer = R_outer)
+  out <- list(events_detected = events_detected, all_events_info = all_events_info, groups_list = groups_list, group_matrix = groups, together = together, R_inner = R_inner, R_outer = R_outer)
   return(out)
 
 }


### PR DESCRIPTION
I did a code review of identify_splits_and_merges(), and made a few changes: 

aa716960bd2f28fabb056491012430de4b98cf3a Added documentation in some places
Found a bug during the bipartite network phase where the end conditions for a while loop were such that the loop never ran more than once. Ari and I discussed the bug and fixed it. This fix didn't change the total number of events identified (as expected), but it did change 41 fusions into shuffles. 

4b7e9fbcc37e51d5f432e5ac816ccc416815ceb2 Added a groups object to the output of the function, which lists for each individual the group membership of that individual at that time. It is the same structure as xs, i.e. a IDxTIMESTEPS matrix. 

4c686f9f0cabf00fb191a70b254b502f1b1f33b4 L. 222 in prior version of the script has a section that identifies matching groups across timesteps. Instead of nested for loops that match groups up one by one, this is now accomplished by checking if all of groups at time A are present in time B (after ensuring that neither are empty). I confirmed that this change produced the exact same output as the prior version of this section of the function. 

763c271eb12c242431c513dbdd7d160ad89df66c L. 283 in prior script used a while looop to delete empty groups one by one, but this is now accomplished with indexing all at once. 

6e6196afbad68aae6b486d1447094b0b5293d763 I changed the name of the object outputed in 4b7e9fbcc37e51d5f432e5ac816ccc416815ceb2 from `groups_matrix` to `groups`